### PR TITLE
Typo in balls and urns

### DIFF
--- a/cookbook.tex
+++ b/cookbook.tex
@@ -2462,7 +2462,7 @@ P(j/n)
 \T{Balls and Urns} \qquad $f: B \to U$ \qquad
 \distinguishable = \T{distinguishable},
 \indistinguishable = \T{indistinguishable}.
-\begin{cente}r
+\begin{center}
   \begin{tabular}[h]{|l*4{|>{\begin{math}\displaystyle}c<{\end{math}}}|}
     \hline &&&&\\[-1.5ex]
     $|B|=n$, $|U|=m$ & f \text{ \T{arbitrary}} & f \text{ \T{injective}} &


### PR DESCRIPTION
Two rows in the table for combinatorics - balls and urns used to have both B distinguishable and U indistinguishable.
