### PR TITLE
Corrected formular for variance of correlated variables

### DIFF
--- a/stat-cookbook.tex
+++ b/stat-cookbook.tex
@@ -539,7 +539,7 @@ Sample mean
 \begin{titemize}{Definition and properties}
   \item $\V{X} = \sigma_X^2 = \E{(X-\E{X})^2} = \E{X^2} - \E{X}^2$
   \item $\V{\displaystyle\sum_{i=1}^n X_i} =
-    \displaystyle\sum_{i=1}^n \V{X_i} + 2\sum_{i\ne j}\cov{X_i,Y_j}$
+    \displaystyle\sum_{i=1}^n \V{X_i} + \sum_{i\ne j}\cov{X_i,X_j}$
 %    \stackrel{X_i \ind X_j}{=}\sum_{i=1}^n\V{X_i}$
   \item $\V{\displaystyle\sum_{i=1}^n X_i} =
     \displaystyle\sum_{i=1}^n\V{X_i} \quad$ if $X_i \ind X_j$


### PR DESCRIPTION
The formula for the variance of correlated variables is wrong.
For now, I only have Wikipedia as reference.
It seems that [this](https://en.wikipedia.org/wiki/Variance#Basic_properties) notation got mixed with that [that](https://en.wikipedia.org/wiki/Variance#Sum_of_correlated_variables.)