### PR TITLE
Fixed formula for a transformation Z=X/Y.

### DIFF
--- a/stat-cookbook.tex
+++ b/stat-cookbook.tex
@@ -473,8 +473,8 @@ Convolution
     f_Z(z)=\displaystyle2\int_0^\infty f_{X,Y}(x,z+x)\,dx$
     %\;\stackrel{X,Y \ge 0}{=}\; \int_0^\infty f_{X,Y}(x,z+x)\,dx$
   \item $ Z:=\displaystyle\frac{X}{Y} \qquad
-    f_Z(z)=\displaystyle\int_{-\infty}^{\infty} |x| f_{X,Y}(x,xz)\,dx
-    \;\stackrel{\ind}{=}\; \int_{-\infty}^{\infty} xf_x(x)f_X(x)f_Y(xz)\,dx$
+    f_Z(z)=\displaystyle\int_{-\infty}^{\infty} |y| f_{X,Y}(yz,y)\,dy
+    \;\stackrel{\ind}{=}\; \int_{-\infty}^{\infty} |y| f_X(yz)f_Y(y)\,dy$
 \end{itemize}
 
 %  \subsection{Joint Distribution}


### PR DESCRIPTION
Hello mavam. I have found some mistakes in one formula.
The first integral will be correct only for a transformation Z = Y/X (see [here](http://math.tntech.edu/ISR/Introduction_to_Probability/Distributions_of_Functions/thispage/newnode16.html) for example) but not for Z=X/Y. 
You can see the correct formula on the wikipedia [here](https://en.wikipedia.org/wiki/Ratio_distribution#Derivation) and [here](https://en.wikipedia.org/wiki/Probability_density_function#Example:_Quotient_distribution). 